### PR TITLE
doc: change the repo URL to GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 ### From git repogitory
 
     -
-    $ git clone --recursive ssh://git@cz-stash.llnl.gov:7999/prun/rempi.git
+    $ git clone --recursive git@github.com:PRUNERS/ReMPI.git
     OR
-    $ git clone ssh://git@cz-stash.llnl.gov:7999/prun/rempi.git
+    $ git clone git@github.com:PRUNERS/ReMPI.git
     $ git submodule update --init
     -
     $ cd <rempi directory>


### PR DESCRIPTION
Use git@github.com:PRUNERS/ReMPI.git instead of LLNL's internal stash git repo.

Resolve Issue #1