### PR TITLE
fixed MPI wrapper search

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -44,38 +44,25 @@ AM_CONDITIONAL([WITH_BLUEGENE], [test "$with_bluegene" = yes])
 
 
 #### Checks for programs.
-LX_FIND_MPI # TODO: AC_LANG_CASE([C++], ...) is not executed
-
-
-
+AC_LANG_PUSH(C)
+LX_FIND_MPI
+test "x$have_C_mpi" = xyes || AC_MSG_ERROR([Failed to find C MPI Wrapper.])
+AC_LANG_POP()
+AC_LANG_PUSH(C++)
+LX_FIND_MPI
+test "x$have_CXX_mpi" = xyes || AC_MSG_ERROR([Failed to find C++ MPI Wrapper.])
+AC_LANG_POP()
+AC_LANG_PUSH(Fortran)
+LX_FIND_MPI
+test "x$have_F_mpi" = xyes || AC_MSG_ERROR([Failed to find Fortran MPI Wrapper.])
+AC_LANG_POP()
 
 AC_CHECK_PROGS([MAKE], [make], [:])
 if test "$MAKE" = :; then
    AC_MSG_ERROR([This package needs make.])
 fi
 
-#AC_CHECK_PROGS([MPICC], [mpicc], [:])
-if test "$MPICC" = :; then
-   AC_MSG_ERROR([This package needs mpicc.])
-fi
-AC_PROG_CC([mpicc])
-AM_PROG_CC_C_O([mpicc])
-AC_PROG_CXX([mpicc])
-#AC_PROG_FC([mpif90])
-AC_SUBST([CC], [$MPICC])
-AC_SUBST([CXX], [$MPICC])
 
-
-
-AC_CHECK_PROGS([MPIF90], [mpif90], [:])
-if test "$MPIF90" = :; then
-   AC_MSG_ERROR([This package needs mpif90.])
-fi
-AC_PROG_FC([mpif90])
-AC_SUBST([FC], [$MPIF90])
-
-
-#AC_ARG_VAR([CC], [CC for compile])
 
 #### Checks for libraries.
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,4 +1,6 @@
-
+CC=$(MPICC)
+CXX=$(MPICXX)
+FC=$(MPIFC)
 AM_CFLAGS = -fPIC -g -Wall -pthread -std=c++0x -I$(clmpi_DIR)/include/ -lstdc++ -I$(libz_a_INCLUDE)
 AM_CXXFLAGS = $(AM_CFLAGS)
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,6 +1,9 @@
 SUBDIRS=../src
 
-AM_CFLAGS = -g -rdynamic  #-lefence
+CC=$(MPICC)
+CXX=$(MPICXX)
+FC=$(MPIFC)
+AM_CFLAGS = -g -rdynamic
 
 if WITH_BLUEGENE	
 LIBS += $(libz_a_LIB) 


### PR DESCRIPTION
This will find the C, CXX, and Fortran MPI wrappers and substitute the appropriate values in each Makefile.