### PR TITLE
fix build system libtool configuration

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -17,7 +17,6 @@ AM_INIT_AUTOMAKE([foreign -Wall -Werror], [0.1])
 ### Action Macros
 m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
 
-AC_PROG_LIBTOOL
 
 AC_SUBST([LIB_CURRENT], [0])
 AC_SUBST([LIB_REVISION], [1])
@@ -57,10 +56,14 @@ LX_FIND_MPI
 test "x$have_F_mpi" = xyes || AC_MSG_ERROR([Failed to find Fortran MPI Wrapper.])
 AC_LANG_POP()
 
+CC="$MPICC"
+CXX="$MPICXX"
+FC="$MPIFC"
 AC_CHECK_PROGS([MAKE], [make], [:])
 if test "$MAKE" = :; then
    AC_MSG_ERROR([This package needs make.])
 fi
+AC_PROG_LIBTOOL
 
 
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,6 +1,3 @@
-CC=$(MPICC)
-CXX=$(MPICXX)
-FC=$(MPIFC)
 AM_CFLAGS = -fPIC -g -Wall -pthread -std=c++0x -I$(clmpi_DIR)/include/ -lstdc++ -I$(libz_a_INCLUDE)
 AM_CXXFLAGS = $(AM_CFLAGS)
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,8 +1,5 @@
 SUBDIRS=../src
 
-CC=$(MPICC)
-CXX=$(MPICXX)
-FC=$(MPIFC)
 AM_CFLAGS = -g -rdynamic
 
 if WITH_BLUEGENE	


### PR DESCRIPTION
Sorry @kento I didn't properly test my previous PR (i.e., with Spack). The previous PR wasn't setting variables in time for libtool to pick them up, so I moved some things around. This builds in my standalone TOSS 3 environment and in Spack.