### PR TITLE
rempi_io_thread: disambiguate count variable ref

### DIFF
--- a/src/rempi/rempi_io_thread.cpp
+++ b/src/rempi/rempi_io_thread.cpp
@@ -77,7 +77,7 @@ void rempi_io_thread::write_record()
       //      input_format->debug_print();
       /*Then, write to file.*/
       encoder->write_record_file();
-      count++;
+      ::count++;
       e = rempi_get_time();
       delete input_format; //TODO: also delete iternal data in this variable
       input_format = encoder->create_encoder_input_format();


### PR DESCRIPTION
This resolves an ambiguous reference to `count` that causes an error when building with `clang`:

```
     921    ./rempi_encoder.h:253:9: warning: field 'tmp_fd_next_clock' will be initialized after field 'file_closed' [-Wreorder-ctor]
     922          , tmp_fd_next_clock(0)
     923            ^
     924    rempi_io_thread.cpp:52:3: warning: delete called on non-final 'rempi_encoder' that has virtual functions but non-virtual destructor [-Wdelete-non-abstract-non-virt
            ual-dtor]
     925      delete encoder;
     926      ^
  >> 927    rempi_io_thread.cpp:80:7: error: reference to 'count' is ambiguous
     928          count++;
     929          ^
     930    rempi_io_thread.cpp:56:5: note: candidate found by name lookup is 'count'
     931    int count = 0;
     932        ^
     933    /usr/local/llvm-doe-6260cb1d4/bin/../include/c++/v1/__bit_reference:313:1: note: candidate found by name lookup is 'std::__1::count'
```

@coti