### PR TITLE
Adding header library to allow compilation

### DIFF
--- a/src/rempi/rempi_message_manager.h
+++ b/src/rempi/rempi_message_manager.h
@@ -26,6 +26,7 @@
 
 #include <unordered_map>
 #include <list>
+#include <string>
 
 #include "mpi.h"
 


### PR DESCRIPTION
I had to add the "string" header library to allow ReMPI to compiler on our Cray system. Adding back this change in case it's useful for others.